### PR TITLE
Fixes example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Pandex enables you to perform any combination of the conversions below:
     defmodule YourApp.Mixfile do
       defp deps do
         [
-          {:pandex, "~> 0.0.3"}
+          {:pandex, "~> 0.1.0"}
         ]
       end
     end


### PR DESCRIPTION
Running `mix deps.get` w/ the existing README code will produce

```
** (Mix) No package version in registry matches pandex ~> 0.0.3 (from: mix.exs)
```

I just updated the readme to reflect version 0.1.0
