### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pandex is a lightweight Elixir wrapper for [Pandoc](http://pandoc.org). It has n
 
 Pandex enables you to perform any combination of the conversions below:
 
-|Convert From (any)  | Convert To (any)   |
+| Convert From (any) | Convert To (any)   |
 |:-------------------|:-------------------|
 | commonmark         | asciidoc           |
 | gfm                | beamer             |
@@ -31,7 +31,7 @@ Pandex enables you to perform any combination of the conversions below:
 |                    | rtf                |
 |                    | s5                 |
 |                    | slidy              |
-|                    |texinfo             |
+|                    | texinfo            |
 |                    | textile            |
 
 `*` Deprecated: `markdown_github`. Use `gfm` instead.
@@ -56,45 +56,46 @@ Pandex enables you to perform any combination of the conversions below:
 
 # Usage
 
-Pandex follows the syntax of `<format from>_to_<format to> <string>`
+Pandex follows the syntax of `<format-from>_to_<format-to>(<string>)`.
 
 ## Examples
 
-```elixir
-iex> Pandex.gfm_to_html("# Title \n\n## List\n\n- one\n- two\n- three\n")
-{:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
+    ```elixir
+    iex> Pandex.gfm_to_html("# Title \n\n## List\n\n- one\n- two\n- three\n")
+    {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
 
-iex> Pandex.latex_to_html5("\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
-{:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"}
+    iex> Pandex.latex_to_html5("\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
+    {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"}
 
-iex> Pandex.latex_to_json("\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
-{:ok, "{\"blocks\":[{\"t\":\"Header\",\"c\":[1,[\"title\",[],[]],[{\"t\":\"Str\",\"c\":\"Title\"}]]},{\"t\":\"Header\",\"c\":[2,[\"list\",[],[]],[{\"t\":\"Str\",\"c\":\"List\"}]]},{\"t\":\"BulletList\",\"c\":[[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"one\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"two\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"three\"}]}]]}],\"pandoc-api-version\":[1,17,5,4],\"meta\":{}}\n"}
-```
+    iex> Pandex.latex_to_json("\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
+    {:ok, "{\"blocks\":[{\"t\":\"Header\",\"c\":[1,[\"title\",[],[]],[{\"t\":\"Str\",\"c\":\"Title\"}]]},{\"t\":\"Header\",\"c\":[2,[\"list\",[],[]],[{\"t\":\"Str\",\"c\":\"List\"}]]},{\"t\":\"BulletList\",\"c\":[[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"one\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"two\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"three\"}]}]]}],\"pandoc-api-version\":[1,17,5,4],\"meta\":{}}\n"}
+    ```
 
 ## Using with your app
 
-``` elixir
-defmodule YourApp do
-  import Pandex
+    ```elixir
+    defmodule YourApp do
+      import Pandex
 
-  def convert(string)  do
-    {:ok, output} = markdown_to_html(string)
-    IO.puts output
-  end
-end
-```
+      def convert(string)  do
+        {:ok, output} = markdown_to_html(string)
+        IO.puts(output)
+      end
+    end
+    ```
 
 You can also give a file as an input. The output will however be a string.
-``` elixir
-defmodule YourApp do
-  import Pandex
 
-  def convert(file)  do
-    {:ok, output} = markdown_file_to_html(file)
-    IO.puts output
-  end
-end
-```
+    ```elixir
+    defmodule YourApp do
+      import Pandex
+
+      def convert(file)  do
+        {:ok, output} = markdown_file_to_html(file)
+        IO.puts(output)
+      end
+    end
+    ```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
 # Pandex
 
-Pandex is a lightweight Elixir wrapper for [Pandoc](http://pandoc.org). Pandex has no dependencies other than Pandoc itself.
+Pandex is a lightweight Elixir wrapper for [Pandoc](http://pandoc.org). It has no dependencies other than Pandoc itself. Pandex unit tests are currently run again Pandoc version 2.5.
 
 Pandex enables you to perform any combination of the conversions below:
 
-|Convert From (any)| Convert To (any)   |
-|:-----------------|:-------------------|
-|markdown          | json               |
-|markdown_github   | html               |
-|markdown_strict   | html5              |
-|markdown_mmd      | s5                 |
-|commonmark        | slidy              |
-|json              | dzslides           |
-|rst               | docbook            |
-|textile           | man                |
-|html              | opendocument       |
-|latex             | latex              |
-|markdown_phpextra | beamer             |
-|                  | context            |
-|                  | texinfo            |
-|                  | markdown           |
-|                  | markdown_github    |
-|                  | markdown_strict    |
-|                  | markdown_mmd       |
-|                  | markdown_phpextra  |
-|                  | commonmark         |
-|                  | plain              |
-|                  | rst                |
-|                  | mediawiki          |
-|                  | textile            |
-|                  | rtf                |
-|                  | org                |
-|                  | asciidoc           |
+|Convert From (any)  | Convert To (any)   |
+|:-------------------|:-------------------|
+| commonmark         | asciidoc           |
+| gfm                | beamer             |
+| html               | commonmark         |
+| json               | context            |
+| latex              | docbook            |
+| markdown           | dzslides           |
+| markdown_github *  | gfm                |
+| markdown_mmd       | html               |
+| markdown_phpextra  | html5              |
+| markdown_strict    | json               |
+| rst                | latex              |
+| textile            | man                |
+|                    | markdown           |
+|                    | markdown_github *  |
+|                    | markdown_mmd       |
+|                    | markdown_phpextra  |
+|                    | markdown_strict    |
+|                    | mediawiki          |
+|                    | opendocument       |
+|                    | org                |
+|                    | plain              |
+|                    | rst                |
+|                    | rtf                |
+|                    | s5                 |
+|                    | slidy              |
+|                    |texinfo             |
+|                    | textile            |
+
+`*` Deprecated: `markdown_github`. Use `gfm` instead.
 
 # Installation
 
@@ -43,7 +46,7 @@ Pandex enables you to perform any combination of the conversions below:
     defmodule YourApp.Mixfile do
       defp deps do
         [
-          {:pandex, "~> 0.1.1"}
+          {:pandex, "~> 0.2.0"}
         ]
       end
     end
@@ -51,70 +54,21 @@ Pandex enables you to perform any combination of the conversions below:
 
 3. Run `mix deps.get` to install `Pandex`.
 
-4. Add `Pandex` your application block in `mix.exs`
-
-    ```elixir
-    defmodule YourApp.Mixfile do
-      use Mix.Project
-
-      def application do
-        [applications: [:logger, :pandex]]
-      end
-    end
-    ```
-
 # Usage
 
 Pandex follows the syntax of `<format from>_to_<format to> <string>`
 
 ## Examples
 
-``` elixir
-iex> Pandex.markdown_to_html "# Title \n\n## List\n\n- one\n- two\n- three\n"
+```elixir
+iex> Pandex.gfm_to_html("# Title \n\n## List\n\n- one\n- two\n- three\n")
 {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
 
-iex> Pandex.html_to_commonmark "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"
-{:ok, "# Title\n\n## List\n\n* one\n* two\n* three\n\n"}
-
-iex> Pandex.html_to_opendocument "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"
-{:ok, "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title</text:h>\n<text:h text:style-name=\"Heading_20_2\" text:outline-level=\"2\">List</text:h>\n<text:list text:style-name=\"L1\">\n  <text:list-item>\n    <text:p text:style-name=\"P1\">one</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">two</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">three</text:p>\n  </text:list-item>\n</text:list>\n"}
-
-iex> Pandex.commonmark_to_latex "# Title \n\n## List\n\n- one\n- two\n- three\n"
-{:ok, "\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"}
-
-iex> Pandex.latex_to_html5 "\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"
+iex> Pandex.latex_to_html5("\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
 {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"}
 
-iex> Pandex.html_to_latex "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"
-{:ok, "\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"}
-
-iex> Pandex.latex_to_json "\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"
-{:ok, "[{\"unMeta\":{}},[{\"t\":\"Header\",\"c\":[1,[\"title\",[],[]],[{\"t\":\"Str\",\"c\":\"Title\"}]]},{\"t\":\"Header\",\"c\":[2,[\"list\",[],[]],[{\"t\":\"Str\",\"c\":\"List\"}]]},{\"t\":\"BulletList\",\"c\":[[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"one\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"two\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"three\"}]}]]}]]\n"}
-
-iex> Pandex.markdown_to_rst "# Title \n\n## List\n\n- one\n- two\n- three\n"
-{:ok, "Title\n=====\n\nList\n----\n\n-  one\n-  two\n-  three\n"}
-
-iex> Pandex.markdown_to_rtf "# Title \n\n## List\n\n- one\n- two\n- three\n"
-{:ok, "{\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs36 Title\\par}\n{\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs32 List\\par}\n{\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab one\\par}\n{\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab two\\par}\n{\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab three\\sa180\\par}\n"}
-
-iex> Pandex.markdown_to_opendocument "# Title \n\n## List\n\n- one\n- two\n- three\n"
-{:ok, "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title</text:h>\n<text:h text:style-name=\"Heading_20_2\" text:outline-level=\"2\">List</text:h>\n<text:list text:style-name=\"L1\">\n  <text:list-item>\n    <text:p text:style-name=\"P1\">one</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">two</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">three</text:p>\n  </text:list-item>\n</text:list>\n"}
-
-iex> Pandex.commonmark_to_textile "# Title \n\n## List\n\n- one\n- two\n- three\n"
-{:ok, "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"}
-
-iex> Pandex.textile_to_markdown_github "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-{:ok, "Title\n=====\n\nList\n----\n\n-   one\n-   two\n-   three\n\n"}
-
-iex> Pandex.textile_to_markdown_phpextra "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-{:ok, "Title {#title}\n=====\n\nList {#list}\n----\n\n-   one\n-   two\n-   three\n\n"}
-
-iex> Pandex.textile_to_html5 "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-{:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
-
-iex> Pandex.textile_to_opendocument "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-{:ok, "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title</text:h>\n<text:h text:style-name=\"Heading_20_2\" text:outline-level=\"2\">List</text:h>\n<text:list text:style-name=\"L1\">\n  <text:list-item>\n    <text:p text:style-name=\"P1\">one</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">two</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">three</text:p>\n  </text:list-item>\n</text:list>\n"}
-
+iex> Pandex.latex_to_json("\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
+{:ok, "{\"blocks\":[{\"t\":\"Header\",\"c\":[1,[\"title\",[],[]],[{\"t\":\"Str\",\"c\":\"Title\"}]]},{\"t\":\"Header\",\"c\":[2,[\"list\",[],[]],[{\"t\":\"Str\",\"c\":\"List\"}]]},{\"t\":\"BulletList\",\"c\":[[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"one\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"two\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"three\"}]}]]}],\"pandoc-api-version\":[1,17,5,4],\"meta\":{}}\n"}
 ```
 
 ## Using with your app
@@ -124,7 +78,7 @@ defmodule YourApp do
   import Pandex
 
   def convert(string)  do
-    {:ok, output} = markdown_to_html string
+    {:ok, output} = markdown_to_html(string)
     IO.puts output
   end
 end
@@ -136,7 +90,7 @@ defmodule YourApp do
   import Pandex
 
   def convert(file)  do
-    {:ok, output} = markdown_file_to_html file
+    {:ok, output} = markdown_file_to_html(file)
     IO.puts output
   end
 end

--- a/lib/pandex.ex
+++ b/lib/pandex.ex
@@ -1,44 +1,41 @@
 defmodule Pandex do
-  @readers ["markdown", "markdown_github", "markdown_strict", "markdown_mmd", "markdown_phpextra", "commonmark", "json", "rst", "textile", "html", "latex"]
-  @writers [ "json", "html", "html5", "s5", "slidy", "dzslides", "docbook", "man",
-            "opendocument", "latex", "beamer", "context", "texinfo", "markdown",
-            "markdown_github", "markdown_strict", "markdown_mmd", "markdown_phpextra", "commonmark",
-            "plain", "rst", "mediawiki", "textile", "rtf", "org", "asciidoc" ]
-
   @moduledoc ~S"""
 
   Pandex is a lightweight ELixir wrapper for [Pandoc](http://pandoc.org). Pandex has no dependencies other than pandoc itself. Pandex enables you to convert Markdown, CommonMark, HTML, Latex, json, html to HTML, HTML5, opendocument, rtf, texttile, asciidoc, markdown, json and others. Pandex has no dependencies other than Pandoc itself.
 
   Pandex enables you to perform any combination of the conversion below:
 
-  |Convert From (any)| Convert To (any)   |
-  |:-----------------|:-------------------|
-  |markdown          | json               |
-  |markdown_github   | html               |
-  |markdown_strict   | html5              |
-  |markdown_mmd      | s5                 |
-  |commonmark        | slidy              |
-  |json              | dzslides           |
-  |rst               | docbook            |
-  |textile           | man                |
-  |html              | opendocument       |
-  |latex             | latex              |
-  |markdown_phpextra | beamer             |
-  |                  | context            |
-  |                  | texinfo            |
-  |                  | markdown           |
-  |                  | markdown_github    |
-  |                  | markdown_strict    |
-  |                  | markdown_mmd       |
-  |                  | markdown_phpextra  |
-  |                  | commonmark         |
-  |                  | plain              |
-  |                  | rst                |
-  |                  | mediawiki          |
-  |                  | textile            |
-  |                  | rtf                |
-  |                  | org                |
-  |                  | asciidoc           |
+  |Convert From (any)  | Convert To (any)   |
+  |:-------------------|:-------------------|
+  | commonmark         | asciidoc           |
+  | gfm                | beamer             |
+  | html               | commonmark         |
+  | json               | context            |
+  | latex              | docbook            |
+  | markdown           | dzslides           |
+  | markdown_github *  | gfm                |
+  | markdown_mmd       | html               |
+  | markdown_phpextra  | html5              |
+  | markdown_strict    | json               |
+  | rst                | latex              |
+  | textile            | man                |
+  |                    | markdown           |
+  |                    | markdown_github *  |
+  |                    | markdown_mmd       |
+  |                    | markdown_phpextra  |
+  |                    | markdown_strict    |
+  |                    | mediawiki          |
+  |                    | opendocument       |
+  |                    | org                |
+  |                    | plain              |
+  |                    | rst                |
+  |                    | rtf                |
+  |                    | s5                 |
+  |                    | slidy              |
+  |                    |texinfo             |
+  |                    | textile            |
+
+  `*` Deprecated: `markdown_github`. Use `gfm` instead.
 
   # Usage
 
@@ -46,108 +43,125 @@ defmodule Pandex do
 
   ## Examples:
 
-      iex> Pandex.markdown_to_html "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
+    iex> Pandex.gfm_to_html("# Title \n\n## List\n\n- one\n- two\n- three\n")
+    {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
 
-      iex> Pandex.html_to_commonmark "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"
-      {:ok, "# Title\n\n## List\n\n* one\n* two\n* three\n\n"}
+    iex> Pandex.latex_to_html5("\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
+    {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"}
 
-      iex> Pandex.html_to_opendocument "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"
-      {:ok, "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title</text:h>\n<text:h text:style-name=\"Heading_20_2\" text:outline-level=\"2\">List</text:h>\n<text:list text:style-name=\"L1\">\n  <text:list-item>\n    <text:p text:style-name=\"P1\">one</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">two</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">three</text:p>\n  </text:list-item>\n</text:list>\n"}
-
-      iex> Pandex.commonmark_to_latex "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"}
-
-      iex> Pandex.latex_to_html5 "\\section{Title}\n\n\\subsection{List}\n\n\\begin{itemize}\n\\tightlist\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"
-      {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"}
-
-      iex> Pandex.html_to_latex "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li><p>one</p></li>\n<li><p>two</p></li>\n<li><p>three</p></li>\n</ul>\n"
-      {:ok, "\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"}
-
-      iex> Pandex.latex_to_json "\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n"
-      {:ok, "[{\"unMeta\":{}},[{\"t\":\"Header\",\"c\":[1,[\"title\",[],[]],[{\"t\":\"Str\",\"c\":\"Title\"}]]},{\"t\":\"Header\",\"c\":[2,[\"list\",[],[]],[{\"t\":\"Str\",\"c\":\"List\"}]]},{\"t\":\"BulletList\",\"c\":[[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"one\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"two\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"three\"}]}]]}]]\n"}
-
-      iex> Pandex.markdown_to_rst "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "Title\n=====\n\nList\n----\n\n-  one\n-  two\n-  three\n"}
-
-      iex> Pandex.markdown_to_rtf "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "{\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs36 Title\\par}\n{\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs32 List\\par}\n{\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab one\\par}\n{\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab two\\par}\n{\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab three\\sa180\\par}\n"}
-
-      iex> Pandex.markdown_to_opendocument "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title</text:h>\n<text:h text:style-name=\"Heading_20_2\" text:outline-level=\"2\">List</text:h>\n<text:list text:style-name=\"L1\">\n  <text:list-item>\n    <text:p text:style-name=\"P1\">one</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">two</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">three</text:p>\n  </text:list-item>\n</text:list>\n"}
-
-      iex> Pandex.commonmark_to_textile "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"}
-
-      iex> Pandex.textile_to_markdown_github "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-      {:ok, "Title\n=====\n\nList\n----\n\n-   one\n-   two\n-   three\n\n"}
-
-      iex> Pandex.textile_to_markdown_phpextra "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-      {:ok, "Title {#title}\n=====\n\nList {#list}\n----\n\n-   one\n-   two\n-   three\n\n"}
-
-      iex> Pandex.textile_to_html5 "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-      {:ok, "<h1 id=\"title\">Title</h1>\n<h2 id=\"list\">List</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"}
-
-      iex> Pandex.textile_to_opendocument "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-      {:ok, "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title</text:h>\n<text:h text:style-name=\"Heading_20_2\" text:outline-level=\"2\">List</text:h>\n<text:list text:style-name=\"L1\">\n  <text:list-item>\n    <text:p text:style-name=\"P1\">one</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">two</text:p>\n  </text:list-item>\n  <text:list-item>\n    <text:p text:style-name=\"P1\">three</text:p>\n  </text:list-item>\n</text:list>\n"}
-
-      iex> Pandex.textile_to_asciidoc "h1. Title\n\nh2. List\n\n* one\n* two\n* three\n\n"
-      {:ok, "[[title]]\nTitle\n-----\n\n[[list]]\nList\n~~~~\n\n* one\n* two\n* three\n"}
-
-      iex> Pandex.markdown_to_asciidoc "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      {:ok, "[[title]]\nTitle\n-----\n\n[[list]]\nList\n~~~~\n\n* one\n* two\n* three\n"}
-
+    iex> Pandex.latex_to_json("\\section{Title}\\label{title}\n\n\\subsection{List}\\label{list}\n\n\\begin{itemize}\n\\item\n  one\n\\item\n  two\n\\item\n  three\n\\end{itemize}\n")
+    {:ok, "{\"blocks\":[{\"t\":\"Header\",\"c\":[1,[\"title\",[],[]],[{\"t\":\"Str\",\"c\":\"Title\"}]]},{\"t\":\"Header\",\"c\":[2,[\"list\",[],[]],[{\"t\":\"Str\",\"c\":\"List\"}]]},{\"t\":\"BulletList\",\"c\":[[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"one\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"two\"}]}],[{\"t\":\"Para\",\"c\":[{\"t\":\"Str\",\"c\":\"three\"}]}]]}],\"pandoc-api-version\":[1,17,5,4],\"meta\":{}}\n"}
   """
 
-  Enum.each @readers, fn (reader) ->
-    Enum.each @writers, fn (writer) ->
-      #function names are atoms. Hence converting String to Atom here. You can also use:
-      # `name = reader <> "_to_" <> writer |> String.to_atom`
-      # convert a string from one format to another.
-      # Example: markdown_to_html5 "# Title \n\n## List\n\n- one\n- two\n- three\n"
-      def unquote(:"#{reader}_to_#{writer}")(string) do
-        convert_string(string, unquote(reader), unquote(writer))
+  @readers [
+    "commonmark",
+    "gfm",
+    "html",
+    "json",
+    "latex",
+    "markdown",
+    "markdown_github",
+    "markdown_mmd",
+    "markdown_phpextra",
+    "markdown_strict",
+    "rst",
+    "textile"
+  ]
+
+  @writers [
+    "asciidoc",
+    "beamer",
+    "commonmark",
+    "context",
+    "docbook",
+    "dzslides",
+    "gfm",
+    "html",
+    "html5",
+    "json",
+    "latex",
+    "man",
+    "markdown",
+    "markdown_github",
+    "markdown_mmd",
+    "markdown_phpextra",
+    "markdown_strict",
+    "mediawiki",
+    "opendocument",
+    "org",
+    "plain",
+    "rst",
+    "rtf",
+    "s5",
+    "slidy",
+    "texinfo",
+    "textile"
+  ]
+
+  @tmp_folder ".tmp"
+
+  Enum.each(@readers, fn reader ->
+    Enum.each(@writers, fn writer ->
+      # Convert a string from one format to another.
+      # Example: `Pandex.markdown_to_html5("# Title \n\n## List\n\n- one\n- two\n- three\n")`
+      def unquote(:"#{reader}_to_#{writer}")(string, options \\ []) do
+        convert_string(string, unquote(reader), unquote(writer), options)
       end
 
-      # convert a file from one format to another.
-      # Example: `markdown_file_to_html("sample.md") `
-      def unquote(:"#{reader}_file_to_#{writer}")(file) do
-        convert_file(file, unquote(reader), unquote(writer))
+      # Convert a file from one format to another.
+      # Example: `Pandex.markdown_file_to_html("sample.md") `
+      def unquote(:"#{reader}_file_to_#{writer}")(file, options \\ []) do
+        convert_file(file, unquote(reader), unquote(writer), options)
       end
-    end
-  end
+    end)
+  end)
 
   @doc """
   `convert_string` works under the hood of all the other string conversion functions.
   """
-  def convert_string(string, from \\ "markdown", to \\ "html", _options \\ []) do
-    if !File.dir?(".temp"), do: File.mkdir ".temp"
-    name = ".temp/" <> random_name
-    File.write name, string
-    {output,_} = System.cmd "pandoc", [name , "--from=#{from}" , "--to=#{to}"]
-    File.rm name
-    {:ok, output}
+  def convert_string(string, from, to, options \\ [])
+      when from in @readers and to in @writers and is_list(options) do
+    unless File.dir?(@tmp_folder), do: File.mkdir(@tmp_folder)
+    file = Path.join(@tmp_folder, random_filename())
+    File.write(file, string)
+
+    result =
+      case System.cmd("pandoc", [file, "--from=#{from}", "--to=#{to}" | options]) do
+        {output, 0} -> {:ok, output}
+        e -> {:error, e}
+      end
+
+    File.rm(file)
+
+    result
   end
 
   @doc """
   `convert_file` works under the hood of all the other functions.
   """
-  def convert_file(file, from \\ "markdown", to \\ "html", _options \\ [] ) do
-    {output,_} = System.cmd "pandoc", [file , "--from=#{from}" , "--to=#{to}"]
-    {:ok, output}
+  def convert_file(file, from, to, options \\ [])
+      when from in @readers and to in @writers and is_list(options) do
+    case System.cmd("pandoc", [file, "--from=#{from}", "--to=#{to}" | options]) do
+      {output, 0} -> {:ok, output}
+      e -> {:error, e}
+    end
   end
 
-  defp random_name do
-    random_string <> "-" <> timestamp <> ".temp"
+  # Private
+
+  defp random_filename do
+    Enum.join([random_string(), "-", timestamp(), ".tmp"])
   end
 
-  defp random_string do
-    :random.seed(:erlang.monotonic_time, :erlang.time_offset, :erlang.unique_integer)
-    0x100000000000000 |> :random.uniform |> Integer.to_string(36) |> String.downcase
+  defp random_string(length \\ 36) do
+    length
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64()
+    |> String.slice(0, length)
+    |> String.downcase()
   end
 
   defp timestamp do
-    {megasec, sec, _microsec} = :os.timestamp
-    megasec*1_000_000 + sec |> Integer.to_string()
+    :os.system_time(:seconds)
   end
 end

--- a/lib/pandex.ex
+++ b/lib/pandex.ex
@@ -119,8 +119,7 @@ defmodule Pandex do
   @doc """
   `convert_string` works under the hood of all the other string conversion functions.
   """
-  def convert_string(string, from, to, options \\ [])
-      when from in @readers and to in @writers and is_list(options) do
+  def convert_string(string, from, to, options \\ []) when is_list(options) do
     unless File.dir?(@tmp_folder), do: File.mkdir(@tmp_folder)
     file = Path.join(@tmp_folder, random_filename())
     File.write(file, string)
@@ -139,8 +138,7 @@ defmodule Pandex do
   @doc """
   `convert_file` works under the hood of all the other functions.
   """
-  def convert_file(file, from, to, options \\ [])
-      when from in @readers and to in @writers and is_list(options) do
+  def convert_file(file, from, to, options \\ []) when is_list(options) do
     case System.cmd("pandoc", [file, "--from=#{from}", "--to=#{to}" | options]) do
       {output, 0} -> {:ok, output}
       e -> {:error, e}

--- a/mix.exs
+++ b/mix.exs
@@ -3,17 +3,17 @@ defmodule Pandex.Mixfile do
 
   def project do
     [
-     app: :pandex,
-     version: "0.1.1",
-     name: "pandex",
-     elixir: "~> 1.0",
-     source_url: "https://github.com/filterkaapi/pandex",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     docs: [extras: ["README.md"]],
-     description: description,
-     package: package,
-     deps: deps
+      app: :pandex,
+      version: "0.2.0",
+      name: "pandex",
+      elixir: "~> 1.0",
+      source_url: "https://github.com/filterkaapi/pandex",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      docs: [extras: ["README.md"]],
+      description: description(),
+      package: package(),
+      deps: deps()
     ]
   end
 
@@ -31,12 +31,15 @@ defmodule Pandex.Mixfile do
   end
 
   defp package do
-    [# These are the default files included in the package
-     files: ["lib", "priv", "mix.exs", "README*", "readme*", "LICENSE*", "license*"],
-     contributors: ["Sandeep Laxman"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/filterkaapi/pandex",
-              "Docs" => "https://github.com/filterkaapi/pandex"}
+    # These are the default files included in the package
+    [
+      files: ["lib", "priv", "mix.exs", "README*", "readme*", "LICENSE*", "license*"],
+      contributors: ["Sandeep Laxman"],
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => "https://github.com/filterkaapi/pandex",
+        "Docs" => "https://github.com/filterkaapi/pandex"
+      }
     ]
   end
 
@@ -50,6 +53,6 @@ defmodule Pandex.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:ex_doc, "~> 0.9", only: :dev}]
+    [{:ex_doc, "~> 0.9", only: [:dev, :test]}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"ex_doc": {:hex, :ex_doc, "0.9.0"}}
+%{
+  "ex_doc": {:hex, :ex_doc, "0.9.0", "e59f4550dc78a07b1d3d81b8728fda772cfb0d54bccf1d7e6bcaab32c01c1f3a", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm"},
+}

--- a/test/pandex_test.exs
+++ b/test/pandex_test.exs
@@ -1,4 +1,562 @@
 defmodule PandexTest do
   use ExUnit.Case, async: true
   doctest Pandex
+
+  @min_version_major 2
+  @min_version_minor 5
+
+  test "pandoc version >= #{@min_version_major}.#{@min_version_minor}" do
+    assert {:ok, [major, minor | _]} = get_pandoc_version()
+    assert major >= @min_version_major and minor >= @min_version_minor
+  end
+
+  test "markdown_to_html" do
+    input = """
+    # Title
+
+    ## List
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    <h1 id="title">Title</h1>
+    <h2 id="list">List</h2>
+    <ul>
+    <li>one</li>
+    <li>two</li>
+    <li>three</li>
+    </ul>
+    """
+
+    assert Pandex.markdown_to_html(input) == {:ok, output}
+  end
+
+  test "html_to_commonmark" do
+    input = """
+    <h1 id="title">Title</h1>
+    <h2 id="list">List</h2>
+    <ul>
+      <li>one</li>
+      <li>two</li>
+      <li>three</li>
+    </ul>
+    """
+
+    output = """
+    # Title
+
+    ## List
+
+      - one
+      - two
+      - three
+    """
+
+    assert Pandex.html_to_commonmark(input) == {:ok, output}
+  end
+
+  test "html_to_opendocument" do
+    input = """
+    <h1 id="title">Title</h1>
+    <h2 id="list">List</h2>
+    <ul>
+    <li>one</li>
+    <li>two</li>
+    <li>three</li>
+    </ul>
+    """
+
+    output = """
+    <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="title" />Title<text:bookmark-end text:name="title" /></text:h>
+    <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="list" />List<text:bookmark-end text:name="list" /></text:h>
+    <text:list text:style-name="L1">
+      <text:list-item>
+        <text:p text:style-name="P1">one</text:p>
+      </text:list-item>
+      <text:list-item>
+        <text:p text:style-name="P1">two</text:p>
+      </text:list-item>
+      <text:list-item>
+        <text:p text:style-name="P1">three</text:p>
+      </text:list-item>
+    </text:list>
+    """
+
+    assert Pandex.html_to_opendocument(input) == {:ok, output}
+  end
+
+  test "commonmark_to_latex" do
+    input = """
+    # Title
+    ## List
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    \\section{Title}
+
+    \\subsection{List}
+
+    \\begin{itemize}
+    \\tightlist
+    \\item
+      one
+    \\item
+      two
+    \\item
+      three
+    \\end{itemize}
+    """
+
+    assert Pandex.commonmark_to_latex(input) == {:ok, output}
+  end
+
+  test "latex_to_html5" do
+    input = """
+    \\section{Title}
+
+    \\subsection{List}
+
+    \\begin{itemize}
+    \\tightlist
+    \\item
+      one
+    \\item
+      two
+    \\item
+      three
+    \\end{itemize}
+    """
+
+    output = """
+    <h1 id="title">Title</h1>
+    <h2 id="list">List</h2>
+    <ul>
+    <li><p>one</p></li>
+    <li><p>two</p></li>
+    <li><p>three</p></li>
+    </ul>
+    """
+
+    assert Pandex.latex_to_html5(input) == {:ok, output}
+  end
+
+  test "html_to_latex" do
+    input = """
+    <h1 id="title">Title</h1>
+    <h2 id="list">List</h2>
+    <ul>
+    <li><p>one</p></li>
+    <li><p>two</p></li>
+    <li><p>three</p></li>
+    </ul>
+    """
+
+    output = """
+    \\hypertarget{title}{%
+    \\section{Title}\\label{title}}
+
+    \\hypertarget{list}{%
+    \\subsection{List}\\label{list}}
+
+    \\begin{itemize}
+    \\item
+      one
+    \\item
+      two
+    \\item
+      three
+    \\end{itemize}
+    """
+
+    assert Pandex.html_to_latex(input) == {:ok, output}
+  end
+
+  test "latex_to_json" do
+    input = """
+    \\section{Title}\\label{title}
+
+    \\subsection{List}\\label{list}
+
+    \\begin{itemize}
+    \\item
+      one
+    \\item
+      two
+    \\item
+      three
+    \\end{itemize}
+    """
+
+    assert {:ok, api_version} = get_pandoc_api_version()
+    api_version = Enum.join(api_version, ",")
+
+    output = """
+    {"blocks":[{"t":"Header","c":[1,["title",[],[]],[{"t":"Str","c":"Title"}]]},{"t":"Header","c":[2,["list",[],[]],[{"t":"Str","c":"List"}]]},{"t":"BulletList","c":[[{"t":"Para","c":[{"t":"Str","c":"one"}]}],[{"t":"Para","c":[{"t":"Str","c":"two"}]}],[{"t":"Para","c":[{"t":"Str","c":"three"}]}]]}],"pandoc-api-version":[#{
+      api_version
+    }],"meta":{}}
+    """
+
+    assert Pandex.latex_to_json(input) == {:ok, output}
+  end
+
+  test "markdown_to_rst" do
+    input = """
+    # Title
+
+    ## List
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    Title
+    =====
+
+    List
+    ----
+
+    -  one
+    -  two
+    -  three
+    """
+
+    assert Pandex.markdown_to_rst(input) == {:ok, output}
+  end
+
+  test "markdown_to_rtf" do
+    input = """
+    # Title
+
+    ## List
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs36 Title\\par}
+    {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs32 List\\par}
+    {\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab one\\par}
+    {\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab two\\par}
+    {\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab three\\sa180\\par}
+
+    """
+
+    assert Pandex.markdown_to_rtf(input) == {:ok, output}
+  end
+
+  test "markdown_to_opendocument" do
+    input = """
+    # Title
+
+    ## List
+
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="title" />Title<text:bookmark-end text:name="title" /></text:h>
+    <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="list" />List<text:bookmark-end text:name="list" /></text:h>
+    <text:list text:style-name="L1">
+      <text:list-item>
+        <text:p text:style-name="P1">one</text:p>
+      </text:list-item>
+      <text:list-item>
+        <text:p text:style-name="P1">two</text:p>
+      </text:list-item>
+      <text:list-item>
+        <text:p text:style-name="P1">three</text:p>
+      </text:list-item>
+    </text:list>
+    """
+
+    assert Pandex.markdown_to_opendocument(input) == {:ok, output}
+  end
+
+  test "commonmark_to_textile" do
+    input = """
+    # Title
+
+    ## List
+
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+
+    """
+
+    assert Pandex.commonmark_to_textile(input) == {:ok, output}
+  end
+
+  test "textile_to_markdown_github" do
+    input = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+    """
+
+    output = """
+    Title
+    =====
+
+    List
+    ----
+
+    -   one
+    -   two
+    -   three
+    """
+
+    assert Pandex.textile_to_markdown_github(input) == {:ok, output}
+  end
+
+  test "textile_to_gfm" do
+    input = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+    """
+
+    output = """
+    # Title
+
+    ## List
+
+      - one
+      - two
+      - three
+    """
+
+    assert Pandex.textile_to_gfm(input) == {:ok, output}
+  end
+
+  test "textile_to_markdown_phpextra" do
+    input = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+    """
+
+    output = """
+    Title {#title}
+    =====
+
+    List {#list}
+    ----
+
+    -   one
+    -   two
+    -   three
+    """
+
+    assert Pandex.textile_to_markdown_phpextra(input) == {:ok, output}
+  end
+
+  test "textile_to_html5" do
+    input = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+    """
+
+    output = """
+    <h1 id="title">Title</h1>
+    <h2 id="list">List</h2>
+    <ul>
+    <li>one</li>
+    <li>two</li>
+    <li>three</li>
+    </ul>
+    """
+
+    assert Pandex.textile_to_html5(input) == {:ok, output}
+  end
+
+  test "textile_to_opendocument" do
+    input = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+    """
+
+    output = """
+    <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="title" />Title<text:bookmark-end text:name="title" /></text:h>
+    <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="list" />List<text:bookmark-end text:name="list" /></text:h>
+    <text:list text:style-name="L1">
+      <text:list-item>
+        <text:p text:style-name="P1">one</text:p>
+      </text:list-item>
+      <text:list-item>
+        <text:p text:style-name="P1">two</text:p>
+      </text:list-item>
+      <text:list-item>
+        <text:p text:style-name="P1">three</text:p>
+      </text:list-item>
+    </text:list>
+    """
+
+    assert Pandex.textile_to_opendocument(input) == {:ok, output}
+  end
+
+  test "textile_to_asciidoc" do
+    input = """
+    h1. Title
+
+    h2. List
+
+    * one
+    * two
+    * three
+    """
+
+    output = """
+    == Title
+
+    === List
+
+    * one
+    * two
+    * three
+    """
+
+    assert Pandex.textile_to_asciidoc(input) == {:ok, output}
+  end
+
+  test "markdown_to_asciidoc" do
+    input = """
+    # Title
+
+    ## List
+
+    - one
+    - two
+    - three
+    """
+
+    output = """
+    == Title
+
+    === List
+
+    * one
+    * two
+    * three
+    """
+
+    assert Pandex.markdown_to_asciidoc(input) == {:ok, output}
+  end
+
+  test "gfm_to_plain" do
+    input = """
+    # Title
+
+    ## List
+
+    - one
+    - two
+    - three
+    """
+
+    output = """
+
+
+    TITLE
+
+
+    List
+
+    -   one
+    -   two
+    -   three
+    """
+
+    assert Pandex.gfm_to_plain(input) == {:ok, output}
+  end
+
+  test "gfm_to_plain with [\"--wrap=none\"] options" do
+    input = """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    """
+
+    output = """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat.
+    """
+
+    output_wrap_none = input
+
+    assert Pandex.gfm_to_plain(input) == {:ok, output}
+    assert Pandex.gfm_to_plain(input, ["--wrap=none"]) == {:ok, output_wrap_none}
+  end
+
+  # Private
+
+  defp get_pandoc_version() do
+    get_version(~r/^pandoc\s*(?<version>[0-9][0-9.]*)(\r\n|\r|\n)/)
+  end
+
+  defp get_pandoc_api_version() do
+    get_version(~r/.*pandoc-types\s*(?<version>[0-9][0-9.]*),.*/)
+  end
+
+  # return version list, e.g. [2, 5]
+  defp get_version(regex) do
+    with {result, 0} <- System.cmd("pandoc", ["--version"]),
+         %{"version" => version} <- Regex.named_captures(regex, result),
+         [_, _ | _] = version <- parse_version(version) do
+      {:ok, version}
+    else
+      _ -> :error
+    end
+  end
+
+  # parse version string into list of integers, e.g. "2.5" returns [2, 5]
+  defp parse_version(version) when is_binary(version) do
+    version
+    |> String.split(".")
+    |> Enum.map(&Integer.parse/1)
+    |> Enum.map(fn {n, _} -> n end)
+  end
+
+  defp parse_version(_), do: :error
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+ExUnit.configure(trace: true)


### PR DESCRIPTION
Thanks for Pandex! I realize this is a pretty big PR so no offense taken if you'd rather not merge this. We're planning to use this fork at [StatMuse](https://github.com/statmuse) though so I figured I'd see if you're interested in these changes. Let me know if you have any questions or feedback. 

- bump version to 0.2.0 (functionality was mostly added in a backwards-compatible manner, sans removal of from/to defaults which will loudly break callers relying on this vs. silently doing something unexpected. via semver `0.y.z` "is for initial development. Anything may change at any time. The public API should not be considered stable.")
- move most tests to pandex_test.exs
- cleanup and fix all tests for pandoc 2.5
- add test that pandoc version >= 2.5
- add note re: deprecated github_markdown format
- add gfm format
- remove potentially confusing from/to defaults
- add guards to convert_string/file
- convert_string/file passes options to System.cmd
- generated helper fns also accept and pass options
- convert_string/file returns :error tuple on failure
- simplify random_filename logic